### PR TITLE
Explicited kamon dependencies

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -77,9 +77,18 @@ object Dependencies {
   }
 
   private[this] object kamon {
-    lazy val namespace  = "io.kamon"
-    lazy val bundle     = namespace %% "kamon-bundle"     % kamonVersion
-    lazy val prometheus = namespace %% "kamon-prometheus" % kamonVersion
+    lazy val namespace             = "io.kamon"
+    lazy val core                  = namespace %% "kamon-core"                   % kamonVersion
+    lazy val prometheus            = namespace %% "kamon-prometheus"             % kamonVersion
+    lazy val statusPage            = namespace %% "kamon-status-page"            % kamonVersion
+    lazy val systemMetrics         = namespace %% "kamon-system-metrics"         % kamonVersion
+    lazy val executors             = namespace %% "kamon-executors"              % kamonVersion
+    lazy val akka                  = namespace %% "kamon-akka"                   % kamonVersion
+    lazy val akkaHttp              = namespace %% "kamon-akka-http"              % kamonVersion
+    lazy val instrumentationCommon = namespace %% "kamon-instrumentation-common" % kamonVersion
+    lazy val scalaFuture           = namespace %% "kamon-scala-future"           % kamonVersion
+    lazy val logback               = namespace %% "kamon-logback"                % kamonVersion
+    lazy val jdbc                  = namespace %% "kamon-jdbc"                   % kamonVersion
   }
 
   private[this] object mustache {
@@ -129,7 +138,16 @@ object Dependencies {
       bouncycastle.kix              % Compile,
       bouncycastle.provider         % Compile,
       cats.core                     % Compile,
-      kamon.bundle                  % Compile,
+      kamon.core                    % Compile,
+      kamon.statusPage              % Compile,
+      kamon.systemMetrics           % Compile,
+      kamon.executors               % Compile,
+      kamon.akka                    % Compile,
+      kamon.akkaHttp                % Compile,
+      kamon.instrumentationCommon   % Compile,
+      kamon.scalaFuture             % Compile,
+      kamon.logback                 % Compile,
+      kamon.jdbc                    % Compile,
       kamon.prometheus              % Compile,
       logback.classic               % Compile,
       mustache.mustache             % Compile,


### PR DESCRIPTION
I noticed together with @beetlecrunch that starting the application with [Bloop](https://scalacenter.github.io/bloop/) instead of the usual sbt, the application was unable to start due to a kamon related runtime error.

What solved the issue was expliciting the dependencies boxed in the kamon-bundle dependency. In particular, I used [this build definition](https://github.com/kamon-io/Kamon/blob/2235b79def2f3ed97c7f282fa2b90a9d0d5c4b0c/build.sbt#L867) to extract all the dependencies explicitly.

The net effect (no pun intended) of this change is that:
 - It should reduce the fat jar dimension if bundling
 - We have explicit control on the metrics that we track
 - We have GC metrics too (see example below)
 - I can use Metals and a text editor instead of Intel`I eat a lot ram`liJ :troll:


Can we consider adding these changes to other projects too?

---

These metrics appeared only once I explicited the dependencies

```
# HELP jvm_gc_seconds Tracks the distribution of GC events duration
# TYPE jvm_gc_seconds histogram
jvm_gc_seconds_bucket{collector="g1-young",le="0.005",component="jvm",generation="young"} 0.0
jvm_gc_seconds_bucket{collector="g1-young",le="0.01",component="jvm",generation="young"} 2.0
jvm_gc_seconds_bucket{collector="g1-young",le="0.025",component="jvm",generation="young"} 2.0
jvm_gc_seconds_bucket{collector="g1-young",le="0.05",component="jvm",generation="young"} 2.0
jvm_gc_seconds_bucket{collector="g1-young",le="0.075",component="jvm",generation="young"} 2.0
jvm_gc_seconds_bucket{collector="g1-young",le="0.1",component="jvm",generation="young"} 2.0
jvm_gc_seconds_bucket{collector="g1-young",le="0.25",component="jvm",generation="young"} 2.0
jvm_gc_seconds_bucket{collector="g1-young",le="0.5",component="jvm",generation="young"} 2.0
jvm_gc_seconds_bucket{collector="g1-young",le="0.75",component="jvm",generation="young"} 2.0
jvm_gc_seconds_bucket{collector="g1-young",le="1.0",component="jvm",generation="young"} 2.0
jvm_gc_seconds_bucket{collector="g1-young",le="2.5",component="jvm",generation="young"} 2.0
jvm_gc_seconds_bucket{collector="g1-young",le="5.0",component="jvm",generation="young"} 2.0
jvm_gc_seconds_bucket{collector="g1-young",le="7.5",component="jvm",generation="young"} 2.0
jvm_gc_seconds_bucket{collector="g1-young",le="10.0",component="jvm",generation="young"} 2.0
jvm_gc_seconds_bucket{collector="g1-young",le="+Inf",component="jvm",generation="young"} 2.0
jvm_gc_seconds_count{component="jvm",collector="g1-young",generation="young"} 2.0
jvm_gc_seconds_sum{component="jvm",collector="g1-young",generation="young"} 0.013
```
