### PR TITLE
Combined Scala Steward PR

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.5.0
+version = 3.5.8
 runner.dialect = scala213
 style = defaultWithAlign
 maxColumn = 120

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -11,7 +11,7 @@ object Versions {
   lazy val kamonVersion     = "2.5.1"
   lazy val logbackVersion   = "1.2.11"
   lazy val mustacheVersion  = "0.9.10"
-  lazy val nimbusVersion    = "9.21"
+  lazy val nimbusVersion    = "9.23"
   lazy val scalaMockVersion = "5.2.0"
   lazy val scalatestVersion = "3.2.11"
 }

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -5,7 +5,7 @@ object Versions {
   lazy val akkaPersistenceS3Version = "1.0.16"
   lazy val akkaVersion              = "2.6.17"
   lazy val bouncycastleVersion      = "1.70"
-  lazy val catsVersion              = "2.7.0"
+  lazy val catsVersion              = "2.8.0"
   lazy val jacksonVersion   = "2.11.4" // This cannot be updated yet because akka-serialization use 2.11.x version
   lazy val json4sVersion    = "4.0.4"
   lazy val kamonVersion     = "2.5.1"

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -13,7 +13,7 @@ object Versions {
   lazy val mustacheVersion  = "0.9.10"
   lazy val nimbusVersion    = "9.21"
   lazy val scalaMockVersion = "5.2.0"
-  lazy val scalatestVersion = "3.2.11"
+  lazy val scalatestVersion = "3.2.12"
 }
 
 object PagopaVersions {

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -7,7 +7,7 @@ object Versions {
   lazy val bouncycastleVersion      = "1.70"
   lazy val catsVersion              = "2.7.0"
   lazy val jacksonVersion   = "2.11.4" // This cannot be updated yet because akka-serialization use 2.11.x version
-  lazy val json4sVersion    = "4.0.4"
+  lazy val json4sVersion    = "4.0.5"
   lazy val kamonVersion     = "2.5.1"
   lazy val logbackVersion   = "1.2.11"
   lazy val mustacheVersion  = "0.9.10"

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -8,7 +8,7 @@ object Versions {
   lazy val catsVersion              = "2.7.0"
   lazy val jacksonVersion   = "2.11.4" // This cannot be updated yet because akka-serialization use 2.11.x version
   lazy val json4sVersion    = "4.0.4"
-  lazy val kamonVersion     = "2.5.1"
+  lazy val kamonVersion     = "2.5.5"
   lazy val logbackVersion   = "1.2.11"
   lazy val mustacheVersion  = "0.9.10"
   lazy val nimbusVersion    = "9.21"

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -8,7 +8,7 @@ object Versions {
   lazy val catsVersion              = "2.7.0"
   lazy val jacksonVersion   = "2.11.4" // This cannot be updated yet because akka-serialization use 2.11.x version
   lazy val json4sVersion    = "4.0.4"
-  lazy val kamonVersion     = "2.5.1"
+  lazy val kamonVersion     = "2.5.4"
   lazy val logbackVersion   = "1.2.11"
   lazy val mustacheVersion  = "0.9.10"
   lazy val nimbusVersion    = "9.21"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.0")
 
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.9")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")
 
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.9")
 
-addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.2.2")
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.2.3")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,4 +12,4 @@ addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.6")
 
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.6")
 
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.10"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.11"


### PR DESCRIPTION
Combining multiple Scala Steward PRs into one.
**Use Squash and Merge** to merge this pr otherwise @TonioGela will hunt you until the end of the world.

## Combined PRs
* Update sbt-scoverage to 2.0.0 in 0.1.x by @pagopa-github-bot
Closes #139
* Update cats-core to 2.8.0 in 0.1.x by @pagopa-github-bot
Closes #137
* Update kamon-akka, kamon-akka-http, ... to 2.5.4 in 0.1.x by @pagopa-github-bot
Closes #131
* Update scalafmt-core to 3.5.8 in 0.1.x by @pagopa-github-bot
Closes #128
* Update nimbus-jose-jwt to 9.23 in 0.1.x by @pagopa-github-bot
Closes #127
* Update compilerplugin, scalapb-runtime to 0.11.11 in 0.1.x by @pagopa-github-bot
Closes #121
* Update scalatest to 3.2.12 in 0.1.x by @pagopa-github-bot
Closes #112
* Update sbt-tpolecat to 0.2.3 in 0.1.x by @pagopa-github-bot
Closes #108
* Update kamon-akka, kamon-akka-http, ... to 2.5.5 in 0.1.x 
Closes #138
* Update json4s-ext, json4s-jackson to 4.0.5 in 0.1.x
Closes #105
