### PR TITLE
Fixed 500 in addClientPurpose if purpose is in draft

### DIFF
--- a/src/main/scala/it/pagopa/interop/authorizationprocess/api/impl/ClientApiServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/authorizationprocess/api/impl/ClientApiServiceImpl.scala
@@ -691,7 +691,6 @@ final case class ClientApiServiceImpl(
         .find(_.id == agreement.descriptorId)
         .toFuture(ClientPurposeAddDescriptorNotFound(purpose.eserviceId.toString, agreement.descriptorId.toString))
       version    <- purpose.versions
-        .filter(_.state != PurposeManagementDependency.PurposeVersionState.DRAFT)
         .maxByOption(_.createdAt)
         .toFuture(ClientPurposeAddPurposeVersionNotFound(purpose.id.toString))
       states = AuthorizationManagementDependency.ClientStatesChainSeed(

--- a/src/main/scala/it/pagopa/interop/authorizationprocess/api/impl/ClientApiServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/authorizationprocess/api/impl/ClientApiServiceImpl.scala
@@ -726,7 +726,10 @@ final case class ClientApiServiceImpl(
         createKeys404(problemOf(StatusCodes.NotFound, ResourceNotFoundError(s"Purpose id ${details.purposeId}")))
       case Failure(ex: ClientPurposeAddAgreementNotFound)              =>
         logger.error(s"Error adding purpose ${details.purposeId} to client $clientId - No valid Agreement found", ex)
-        createKeys400(problemOf(StatusCodes.BadRequest, ex))
+        createKeys404(problemOf(StatusCodes.NotFound, ex))
+      case Failure(ex: ClientPurposeAddPurposeVersionNotFound)         =>
+        logger.error(s"Error adding purpose ${details.purposeId} to client $clientId - No valid Purpose found", ex)
+        createKeys404(problemOf(StatusCodes.NotFound, ex))
       case Failure(ex)                                                 =>
         logger.error(s"Error adding purpose ${details.purposeId} to client $clientId", ex)
         internalServerError(


### PR DESCRIPTION
I fixed the 500 to a 404, although there's still a UX bug. This API is called right before the finalization of the purpose creation, so the purpose will ALWAYS be in a draft state. We have to understand what will happen if we relax the requirement.